### PR TITLE
Avoid use Task.Delay().Wait()

### DIFF
--- a/src/DotNetty.Common/Concurrency/XThread.cs
+++ b/src/DotNetty.Common/Concurrency/XThread.cs
@@ -121,7 +121,16 @@ namespace DotNetty.Common.Concurrency
 
         public static void Sleep(int millisecondsTimeout)
         {
-            Task.Delay(millisecondsTimeout).Wait();
+            Thread.Sleep(millisecondsTimeout);
+        }
+
+        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken" /> was canceled.</exception>
+        public static void Sleep(int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            using (var ev = new ManualResetEventSlim())
+            {
+                ev.Wait(millisecondsTimeout, cancellationToken);
+            }
         }
 
         public int Id => _threadId;

--- a/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
+++ b/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
@@ -423,15 +423,13 @@ namespace DotNetty.Common.Utilities
                             : currentTime;
                     }
 
-                    Task delay = null;
                     try
                     {
                         long sleepTimeMs = sleepTime.Ticks / TimeSpan.TicksPerMillisecond; // we've already rounded so no worries about the remainder > 0 here
                         Debug.Assert(sleepTimeMs <= int.MaxValue);
-                        delay = Task.Delay((int)sleepTimeMs, _owner.CancellationToken);
-                        delay.Wait();
+                        XThread.Sleep((int)sleepTimeMs, _owner.CancellationToken);
                     }
-                    catch (AggregateException) when (delay is object && delay.IsCanceled)
+                    catch (OperationCanceledException)
                     {
                         if (Volatile.Read(ref _owner.v_workerState) == WorkerStateShutdown)
                         {


### PR DESCRIPTION
use method with no HANDLE alloc, fix #37

See details in dotnet/runtime#47752

DotNetty used Task.Delay().Wait() when switch to netstandard, since `Thread.Sleep()` is not supported in netstandard1.3, but now netstandard1.3 is already not supported by SpanNetty.