### PR TITLE
Fix empty buffer handling in TlsHandler

### DIFF
--- a/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
@@ -170,7 +170,6 @@ namespace DotNetty.Handlers.Tls
                             composite.Release();
                         }
                         _lastContextWritePromise = promise;
-                        _ = buf.ReadBytes(_sslStream, readableBytes); // this leads to FinishWrap being called 0+ times
                         if (buf.IsReadable())
                         {
                             _ = buf.ReadBytes(_sslStream, readableBytes); // this leads to FinishWrap being called 0+ times

--- a/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs
@@ -38,6 +38,8 @@ namespace DotNetty.Handlers.Tls
 
     partial class TlsHandler
     {
+        static readonly byte[] ZeroBuf = new byte[0];
+        
         private IPromise _lastContextWritePromise;
         private volatile int v_wrapDataSize = TlsUtils.MAX_PLAINTEXT_LENGTH;
 
@@ -169,6 +171,14 @@ namespace DotNetty.Handlers.Tls
                         }
                         _lastContextWritePromise = promise;
                         _ = buf.ReadBytes(_sslStream, readableBytes); // this leads to FinishWrap being called 0+ times
+                        if (buf.IsReadable())
+                        {
+                            _ = buf.ReadBytes(_sslStream, readableBytes); // this leads to FinishWrap being called 0+ times
+                        }
+                        else if (promise != null)
+                        {
+                            FinishWrap(ZeroBuf, 0, 0, promise);
+                        }
                     }
                     catch (Exception exc)
                     {


### PR DESCRIPTION
Problem: promise associated with writing empty buffer to TlsHandler never completes because EmptyByteBuffer doesn't write anything on .ReadBytes call to passed stream: https://github.com/cuteant/SpanNetty/blob/9f31f09ca110c6a3994966f860ee54b6a1836d75/src/DotNetty.Handlers/Tls/TlsHandler.Writer.cs#L171

Minimal repro: https://github.com/maksimkim/DotNetty/blob/2a35ea6df4b57f33997cb00702a1c712d6a17c6b/examples/HttpClient/Program.cs#L60

await channel.WriteAndFlushAsync(EmptyLastHttpContent.Default) never completes.

Solution: special case handling for empty buffer
