### PR TITLE
HTTP 1.1 Method should be case-sensitive according to specs

### DIFF
--- a/src/DotNetty.Codecs.Http/HttpMethod.cs
+++ b/src/DotNetty.Codecs.Http/HttpMethod.cs
@@ -279,14 +279,12 @@ namespace DotNetty.Codecs.Http
 
         private static HttpMethod ConvertToHttpMethod(string name)
         {
-            var methodName = name.ToUpperInvariant();
-
-            if (MethodMap.TryGetValue(methodName, out var result))
+            if (MethodMap.TryGetValue(name, out var result))
             {
                 return result;
             }
 
-            return new HttpMethod(methodName);
+            return new HttpMethod(name);
         }
     }
 }

--- a/test/DotNetty.Codecs.Http.Tests/HttpMethodTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpMethodTest.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Codecs.Http.Tests
+{
+    using DotNetty.Common.Utilities;
+    using Xunit;
+
+    public sealed class HttpMethodTest
+    {
+        [Fact]
+        public void ValueOf_NonStandardVerb_HonorCaseSensitivity()
+        {
+            var expectedHttpMethod = "Foo";
+            var httpMethod = HttpMethod.ValueOf(new AsciiString(expectedHttpMethod));
+            Assert.Equal(expectedHttpMethod, httpMethod.Name);
+        }
+    }
+}


### PR DESCRIPTION
According to the HTTP 1.1 specs for Method:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1

"The Method token indicates the method to be performed on the resource identified by the Request-URI. The method is case-sensitive."

The current code is forcing all methods to uppercase.
A server can allow arbitrary and case-sensitive HTTP method verbs. 