### PR TITLE
Fix CompositeByteBuffer.ComponentAtOffset()

### DIFF
--- a/src/DotNetty.Buffers/CompositeByteBuffer.cs
+++ b/src/DotNetty.Buffers/CompositeByteBuffer.cs
@@ -112,7 +112,7 @@ namespace DotNetty.Buffers
 
             public IByteBuffer Duplicate()
             {
-                return SrcBuffer.Duplicate();
+                return Slice().Duplicate();
             }
 
             public void Free()


### PR DESCRIPTION
Like #75, it should also use right index for slice