### PR TITLE
Fix encryption alert write during TLS handshake

### DIFF
--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetCore.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetCore.cs
@@ -177,10 +177,10 @@ namespace DotNetty.Handlers.Tls
             }
 
             public override void Write(ReadOnlySpan<byte> buffer)
-                => _owner.FinishWrap(buffer, _owner._lastContextWritePromise);
+                => _owner.FinishWrap(buffer, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
 
             public override void Write(byte[] buffer, int offset, int count)
-                => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise);
+                => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {

--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetCore.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetCore.cs
@@ -177,10 +177,10 @@ namespace DotNetty.Handlers.Tls
             }
 
             public override void Write(ReadOnlySpan<byte> buffer)
-                => _owner.FinishWrap(buffer, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
+                => _owner.FinishWrap(buffer, _owner._lastContextWritePromise ?? _owner.CapturedContext.NewPromise());
 
             public override void Write(byte[] buffer, int offset, int count)
-                => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
+                => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.NewPromise());
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {

--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetFx.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetFx.cs
@@ -145,7 +145,7 @@ namespace DotNetty.Handlers.Tls
                 return length;
             }
 
-            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise);
+            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => _owner.FinishWrapNonAppDataAsync(buffer, offset, count, _owner.CapturedContext.NewPromise());

--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetFx.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetFx.cs
@@ -145,7 +145,7 @@ namespace DotNetty.Handlers.Tls
                 return length;
             }
 
-            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
+            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.NewPromise());
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => _owner.FinishWrapNonAppDataAsync(buffer, offset, count, _owner.CapturedContext.NewPromise());

--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetStandard20.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetStandard20.cs
@@ -108,7 +108,7 @@ namespace DotNetty.Handlers.Tls
                 return length;
             }
 
-            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise);
+            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => _owner.FinishWrapNonAppDataAsync(buffer, offset, count, _owner.CapturedContext.NewPromise());

--- a/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetStandard20.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.MediationStream.NetStandard20.cs
@@ -108,7 +108,7 @@ namespace DotNetty.Handlers.Tls
                 return length;
             }
 
-            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.VoidPromise());
+            public override void Write(byte[] buffer, int offset, int count) => _owner.FinishWrap(buffer, offset, count, _owner._lastContextWritePromise ?? _owner.CapturedContext.NewPromise());
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => _owner.FinishWrapNonAppDataAsync(buffer, offset, count, _owner.CapturedContext.NewPromise());


### PR DESCRIPTION
Problem: When server certificate validation fails, client SslStream tries to write Encryption Alert TLS message to the underlying stream. It fails with NRE trying to use uninitialized TlsHandler._lastContextWritePromise. 

Solution: use void promise when _lastContextWritePromise is empty