### PR TITLE
Observe AbstractCoalescingBufferQueue.ReleaseAndFailAll failure task

### DIFF
--- a/src/DotNetty.Transport/Channels/AbstractCoalescingBufferQueue.cs
+++ b/src/DotNetty.Transport/Channels/AbstractCoalescingBufferQueue.cs
@@ -202,7 +202,10 @@ namespace DotNetty.Transport.Channels
         /// </summary>
         public void ReleaseAndFailAll(Exception cause)
         {
-            ReleaseAndCompleteAll(TaskUtil.FromException(cause));
+            var failedTask = TaskUtil.FromException(cause);
+            //if _bufAndListenerPairs queue is empty, the task will end up unobserved 
+            failedTask.Ignore();
+            ReleaseAndCompleteAll(failedTask);
         }
 
         /// <summary>


### PR DESCRIPTION
When TLS connection is gettings closed, TlsHandler tries to mark all pending writes as failed by creating fail task. If there's no pending writes, this task will be left unobserved.